### PR TITLE
Correção da busca de endereços no site dos Correios

### DIFF
--- a/src/CepGratis.php
+++ b/src/CepGratis.php
@@ -20,9 +20,9 @@
 
             $client		= new Client();
     		$crawler 	= $client->request('POST', 'http://www.buscacep.correios.com.br/sistemas/buscacep/resultadoBuscaCepEndereco.cfm', [
-                'relaxation'	=> Utils::unmask($cep),
-                'tipoCEP'		=> 'ALL',
-                'semelhante'	=> 'N'
+                'relaxation'  => Utils::unmask($cep),
+                'tipoCEP'     => 'ALL',
+                'semelhante'  => 'N'
             ]);
 
             // Realiza a filtragem para que somente a linha que contenha os
@@ -48,6 +48,6 @@
             $endereco['cidade'] = $separado[0];
             $endereco['uf']     = $separado[1];
 
-            return array_map('htmlentities', array_map('trim', $endereco));
+            return str_replace('&nbsp;', '', array_map('htmlentities', array_map('trim', $endereco)));
         }
     }

--- a/tests/CepGratisTest.php
+++ b/tests/CepGratisTest.php
@@ -13,7 +13,7 @@ class CepGratisTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('Rua Alabastro', $endereco['logradouro']);
         $this->assertEquals('Sagrada Fam&iacute;lia', $endereco['bairro']);
         $this->assertEquals('Belo Horizonte', $endereco['cidade']);
-        $this->assertEquals('31030080', $endereco['cep']);
+        $this->assertEquals('31030-080', $endereco['cep']);
         $this->assertEquals('MG', $endereco['uf']);
         
         
@@ -22,7 +22,7 @@ class CepGratisTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('', $endereco['logradouro']);
         $this->assertEquals('', $endereco['bairro']);
         $this->assertEquals('Catu', $endereco['cidade']);
-        $this->assertEquals('48110000', $endereco['cep']);
+        $this->assertEquals('48110-000', $endereco['cep']);
         $this->assertEquals('BA', $endereco['uf']);
         
     }


### PR DESCRIPTION
- Correção na busca de CEPs no site dos correios, visto que, o endereço e alguns parâmetros sofreram profunda mudança.

Detalhe: Tive que mexer na classe Cookie do browser-kit, pois o mesmo apresentava um erro no decorrer da execução.

_**Synfony\Component\BrowserKit\Cookie**_

**Linha 73**
Antigo:
`if (null !== $expires)`

Novo
`if(null !== $expires || $expires !== false) {
    $expires = 0;
`
