### PR TITLE
Criação da exception CepNotFoundException

### DIFF
--- a/src/CepGratis.php
+++ b/src/CepGratis.php
@@ -2,6 +2,7 @@
 namespace JansenFelipe\CepGratis;
 
 use Exception;
+use InvalidArgumentException;
 use Goutte\Client;
 use JansenFelipe\Utils\Utils as Utils;
 
@@ -15,8 +16,9 @@ class CepGratis {
      */
     public static function consulta($cep) {
 
-        if (strlen($cep) < 8)
-            throw new Exception('O cep informado não parece ser válido');
+        if (strlen($cep) < 8) {
+            throw new InvalidArgumentException('O cep informado não parece ser válido');
+        }
 
         $client		= new Client();
         $crawler 	= $client->request('POST', 'http://www.buscacep.correios.com.br/sistemas/buscacep/resultadoBuscaCepEndereco.cfm', [
@@ -30,8 +32,9 @@ class CepGratis {
         $tr = $crawler->filter(".tmptabela > tr:nth-child(2)");
 
         // Se a tabela nao existir, nao foi encontrado nenhum resultado
-        if(!$tr->count())
-            throw new Exception('O cep informado não existe');
+        if(!$tr->count()) {
+            throw new CepNotFoundException;
+        }
 
         // Recebe o endereço obtido através da consulta
         $endereco = [

--- a/src/CepGratis.php
+++ b/src/CepGratis.php
@@ -33,7 +33,7 @@ class CepGratis {
 
         // Se a tabela nao existir, nao foi encontrado nenhum resultado
         if(!$tr->count()) {
-            throw new CepNotFoundException;
+            throw new CepNotFoundException('O cep informado não existe');
         }
 
         // Recebe o endereço obtido através da consulta

--- a/src/CepNotFoundException.php
+++ b/src/CepNotFoundException.php
@@ -1,0 +1,22 @@
+<?php
+
+    namespace JansenFelipe\CepGratis;
+
+    use Exception;
+
+    /**
+     * CepNotFoundException
+     *
+     * Define a exception para cep não encontrado
+     *
+     * @author  Matheus Lopes Santos <fale_com_lopez@hotmail.com>
+     * @version 1.0.0
+     * @since   10/03/2017
+     */
+    class CepNotFoundException extends Exception
+    {
+        /**
+         * @var string
+         */
+        protected $message = 'O cep informado não existe';
+    }

--- a/tests/CepGratisTest.php
+++ b/tests/CepGratisTest.php
@@ -16,15 +16,33 @@ class CepGratisTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('Belo Horizonte', $endereco['cidade']);
         $this->assertEquals('31030-080', $endereco['cep']);
         $this->assertEquals('MG', $endereco['uf']);
-        
-        
+
+
         $endereco = CepGratis::consulta('48110000');
-        
+
         $this->assertEquals('', $endereco['logradouro']);
         $this->assertEquals('', $endereco['bairro']);
         $this->assertEquals('Catu', $endereco['cidade']);
         $this->assertEquals('48110-000', $endereco['cep']);
         $this->assertEquals('BA', $endereco['uf']);
+    }
+
+    /**
+     * @expectedException   \JansenFelipe\CepGratis\CepNotFoundException
+     * @expectedExceptionMessage O cep informado não existe
+     */
+    public function testCepException()
+    {
+        CepGratis::consulta('12345678');
+    }
+
+    /**
+     * @expectedException   \InvalidArgumentException
+     * @expectedExceptionMessage O cep informado não parece ser válido
+     */
+    public function testInvalidCep()
+    {
+        CepGratis::consulta('');
     }
 
     public function testConsultaCepInexistente()

--- a/tests/CepGratisTest.php
+++ b/tests/CepGratisTest.php
@@ -44,14 +44,4 @@ class CepGratisTest extends PHPUnit_Framework_TestCase {
     {
         CepGratis::consulta('');
     }
-
-    public function testConsultaCepInexistente()
-    {
-        try{
-            CepGratis::consulta('12345678');
-        }catch (Exception $e){
-            $this->assertEquals('O cep informado não existe', $e->getMessage());
-        }
-    }
-
 }


### PR DESCRIPTION
Criação da exception `CepNotFoundException` e troca do lançamento de `Exception` para `InvalidArgumentException` quando o cep é inválido